### PR TITLE
Fixed a bug where some keywords could not be fully colored

### DIFF
--- a/syntaxes/gjf.tmLanguage.json
+++ b/syntaxes/gjf.tmLanguage.json
@@ -53,55 +53,55 @@
 			]
 		},
 		"scrf": {
-			"match": "(?i)(scrf|solvent)",
-			"name": "variable.language"
-		},
-		"guess": {
-			"match": "(?i)(guess|read|tcheck)",
+			"match": "\\b(?i)(scrf|solvent)\\b",
 			"name": "variable.language"
 		},
 		"geometry": {
-			"match": "(?i)(geom|checkpoint|allcheck|connectivity|nodistance)",
+			"match": "\\b(?i)(geom|checkpoint|allcheck|connectivity|nodistance)\\b",
 			"name": "variable.language"
 		},
 		"opt-irc": {
-			"match": "(?i)(readopt|calcfc|readfc|rcfc|calcall|symmetry|restart|pseudo|maxpoints|recalc|stepsize|ts|maxstep|eigentest|noeigentest|forward|reverse|z-matrix|modredundant|redundant|cartesian|gediis|rfo|ef)",
+			"match": "\\b(?i)(readopt|calcfc|readfc|rcfc|calcall|symmetry|restart|pseudo|maxpoints|recalc|stepsize|ts|maxstep|eigentest|noeigentest|forward|reverse|z-matrix|modredundant|redundant|cartesian|gediis|rfo|ef)\\b",
+			"name": "variable.language"
+		},
+        "guess": {
+			"match": "\\b(?i)(guess|read|tcheck)\\b",
 			"name": "variable.language"
 		},
 		"scf": {
-			"match": "(?i)(scf|maxcycle|conver|qc)",
+			"match": "\\b(?i)(scf|maxcycle|conver|qc)\\b",
 			"name": "variable.language"
 		},
 		"integral-cphf": {
-			"match": "(?i)(integral|int|cphf|grid|fine|finegrid|ultrafine|ultrafinegrid|superfine|superfinegrid|coarse|coarsegrid|sg1|sg1grid)",
+			"match": "\\b(?i)(integral|int|cphf|grid|fine|finegrid|ultrafine|ultrafinegrid|superfine|superfinegrid|coarse|coarsegrid|sg1|sg1grid)\\b",
 			"name": "variable.language"
 		},
 		"population-analysis": {
-			"match": "(?i)(pop|full|nbo|nbo6|nbo6read)",
+			"match": "\\b(?i)(pop|full|nbo|nbo6|nbo6read)\\b",
 			"name": "variable.language"
 		},
 		"other": {
-			"match": "(?i)nosymm",
+			"match": "\\b(?i)nosymm\\b",
 			"name": "variable.language"
 		},
 		"td": {
-			"match": "(?i)(singlets|triplets|root)",
+			"match": "\\b(?i)(singlets|triplets|root)\\b",
 			"name": "variable.language"
 		},
 		"com-cmd": {
-			"match": "(?i)(irc|opt|fopt|popt|freq|nmr|td)",
+			"match": "\\b(?i)(irc|opt|fopt|popt|freq|nmr|td)\\b",
 			"name": "keyword.control"
 		},
 		"com-link-0": {
-			"match": "(?i)(nprocshared|mem|chk|oldchk|rwf|lindaworkers|usessh|save|nosave)",
+			"match": "\\b(?i)(nprocshared|mem|chk|oldchk|rwf|lindaworkers|usessh|save|nosave)\\b",
 			"name": "keyword.control"
 		},
 		"com-basis": {
-			"match": "(?i)(sto-3g|3-21g|6-21g|6-31g|6-311g|d95v|d95|shc|cep-4g|cep-31g|cep-121g|lanl2mb|lanl2dz|sdd|sddall|cc-pvdz|cc-pvtz|cc-pvqz|cc-pv5z|cc-pv6z|sv|svp|tzv|tzvp|def2sv|def2svp|def2svpp|def2tzv|def2tzvp|def2tzvpp|def2qzv|def2qzvp|def2qzvpp|qzvp|midix|epr-ii|epr-iii|ugbs|mtsmall|w06|fit|notfit|auto)",
+			"match": "\\b(?i)(sto-3g|3-21g|6-21g|6-31g|6-311g|d95v|d95|shc|cep-4g|cep-31g|cep-121g|lanl2mb|lanl2dz|sddall|sdd|cc-pvdz|cc-pvtz|cc-pvqz|cc-pv5z|cc-pv6z|svp|sv|tzvp|tzv|def2svpp|def2svp|def2sv|def2tzvpp|def2tzvp|def2tzv|def2qzvpp|def2qzvp|def2qzv|qzvp|midix|epr-iii|epr-ii|ugbs|mtsmall|w06|fit|notfit|auto)\\b",
 			"name": "support.function"
 		},
 		"com-method": {
-			"match": "(?i)(hf|mp2|mp3|mp4|mp5|b2plyp|mpw2plyp|ci|b3lyp|b3p86|b3pw91|o3lyp|apfd|apf|wb97xd|lc-whpbe|lc-wpbe|cam-b3lyp|wb97xd|wb97|wb97x|mn15|m11|sogga11x|n12sx|mn12sx|pw6b95|pw6b95d3|m08hx|m06|m06hf|m062x|m05|m052x|pbe1pbe|hseh1pbe|ohse2pbe|ohse1pbe|pbeh1pbe|b1b95|b1lyp|mpw1pw91|mpw1lyp|mpw1pbe|mpw3pbe|b98|b971|b972|tpssh|thcthhyb|bmk|hissbpbe|x3lyp|bhandh|bhandhlyp|iop)",
+			"match": "\\b(?i)(hf|mp2|mp3|mp4|mp5|b2plyp|mpw2plyp|ci|b3lyp|b3p86|b3pw91|o3lyp|apfd|apf|wb97xd|lc-whpbe|lc-wpbe|cam-b3lyp|wb97xd|wb97x|wb97|mn15|m11|sogga11x|n12sx|mn12sx|pw6b95d3|pw6b95|m08hx|m06hf|m062x|m06|m052x|m05|pbe1pbe|hseh1pbe|ohse2pbe|ohse1pbe|pbeh1pbe|b1b95|b1lyp|mpw1pw91|mpw1lyp|mpw1pbe|mpw3pbe|b98|b971|b972|tpssh|thcthhyb|bmk|hissbpbe|x3lyp|bhandhlyp|bhandh|iop)\\b",
 			"name": "support.function"
 		},
 		"string-double": {


### PR DESCRIPTION
By adjusting the order of keywords in the regular expression, some long keywords can be matched first, so as to fix the bug that some keywords cannot be completely colored. For example, in the previous project `def2svp` only `def2sv` was properly colored, while `p` could not be colored.
In addition, `\b` is added to the match to achieve the match of the whole word.